### PR TITLE
feat: Twig now accepts multiple folders roots under its namespaces.

### DIFF
--- a/src/Bootstrap/Twig.php
+++ b/src/Bootstrap/Twig.php
@@ -17,16 +17,10 @@ class Twig implements AppModuleInterface
     $isDevelopment = $config->env->development;
     $isDebug = $config->env->debug;
 
-    $templatesPath = Path::join($appRoot, 'templates');
+    $defaultViewsPath = Path::join(__DIR__, '..', 'Views');
     $cachePath =  Path::join($appRoot, 'cache', 'twig');
 
-    if (!file_exists($templatesPath)) {
-      if (!mkdir($templatesPath, 0777)) {
-        throw new \Exception('Failed to create templates directory');
-      }
-    }
-
-    $twig = TwigViews::create($templatesPath, [
+    $twig = TwigViews::create([$defaultViewsPath], [
       'cache' => !$isDebug && !$isDevelopment ? $cachePath : false,
     ]);
 

--- a/src/Bootstrap/Twig.php
+++ b/src/Bootstrap/Twig.php
@@ -20,6 +20,12 @@ class Twig implements AppModuleInterface
     $defaultViewsPath = Path::join(__DIR__, '..', 'Views');
     $cachePath =  Path::join($appRoot, 'cache', 'twig');
 
+    if (!file_exists($defaultViewsPath)) {
+      if (!mkdir($defaultViewsPath, 0777)) {
+        throw new \Exception('Failed to create templates directory');
+      }
+    }
+
     $twig = TwigViews::create([$defaultViewsPath], [
       'cache' => !$isDebug && !$isDevelopment ? $cachePath : false,
     ]);


### PR DESCRIPTION
Views folder in the root is now not read as default. Instead there is an option to automatically detect Views folder in each plugin and set it under namespace.